### PR TITLE
ci: add step to upload coverage to codecov

### DIFF
--- a/.github/workflows/poetry-codecov-reusable.yml
+++ b/.github/workflows/poetry-codecov-reusable.yml
@@ -1,8 +1,12 @@
-name: Build Poetry Project (Reusable)
+name: Test Poetry Project and Upload Coverage to Codecov (Reusable)
 
 on:
   workflow_call:
     inputs:
+        working-directory:
+            description: 'Working directory to use'
+            required: true
+            type: string
         python-version:
             description: 'Python version to use'
             required: true
@@ -15,6 +19,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -46,3 +53,10 @@ jobs:
       # Requires installation of pytest and pytest-cov
       - name: Test with pytest
         run: poetry run pytest --doctest-modules --cov=${{ inputs.module-name }} --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ inputs.working-directory }}
+          files: coverage.xml


### PR DESCRIPTION
### Summary of Changes

Since it's not possible to add more steps after calling a reusable workflow, I've added the step to upload coverage to the workflow.
