### PR TITLE
ci: use semantic-release to publish to PyPI

### DIFF
--- a/.github/workflows/poetry-codecov-reusable.yml
+++ b/.github/workflows/poetry-codecov-reusable.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       module-name:
-        description: 'Name of the module to build'
-        required: true
+        description: 'Name of the module to build. Must be provided if coverage is enabled.'
+        required: false
         type: string
       coverage:
         description: 'Whether to upload coverage to Codecov'

--- a/.github/workflows/poetry-pypi-reusable.yml
+++ b/.github/workflows/poetry-pypi-reusable.yml
@@ -15,10 +15,21 @@ on:
       PYPI_TOKEN:
         description: 'PyPI token'
         required: true
+      GITHUB_PAT:
+        description: 'GitHub Personal Access Token'
+        required: false
 
 jobs:
-  publish:
+  build:
+    uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
+    with:
+      working-directory: ${{ inputs.working-directory }}
+      python-version: ${{ inputs.python-version }}
+      coverage: false
+
+  release:
     runs-on: ubuntu-latest
+    needs: build
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -38,24 +49,7 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3.2.3
+      - uses: bjoluc/semantic-release-config-poetry@v2.2.0
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install library
-        run: poetry install --no-interaction
-
-      - name: Test with pytest
-        run: poetry run pytest --doctest-modules
-
-      - name: Publish
-        run: poetry publish --build
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          github_token: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary of Changes

Use `semantic-release` to publish to PyPI.
