### PR TITLE
ci: fix poetry caching

### DIFF
--- a/.github/workflows/poetry-codecov-reusable.yml
+++ b/.github/workflows/poetry-codecov-reusable.yml
@@ -35,30 +35,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install Poetry
+        run: pipx install poetry
+
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
+          cache: 'poetry'
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3.2.3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install library
+      - name: Install Python dependencies
         run: poetry install --no-interaction
 
       - name: Test with pytest

--- a/.github/workflows/poetry-pypi-reusable.yml
+++ b/.github/workflows/poetry-pypi-reusable.yml
@@ -36,17 +36,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Poetry
+        run: pipx install poetry
+
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
+          cache: 'poetry'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -55,7 +52,7 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
-      - name: Install dependencies
+      - name: Install NPM dependencies
         run: npm ci
 
       - name: Release


### PR DESCRIPTION
### Summary of Changes

Caching of Poetry dependencies never worked with the old setup. According to [this](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages), it should now work properly.